### PR TITLE
Call fill-paragraph interactively

### DIFF
--- a/fill-function-arguments.el
+++ b/fill-function-arguments.el
@@ -221,7 +221,7 @@ Borrowed from s.el to avoid a dependency"
             (indent-region (point-min) (point-max))))))))
 
 ;;;###autoload
-(defun fill-function-arguments-dwim ()
+(defun fill-function-arguments-dwim (&optional arg)
   "Fill the thing at point in a context-sensitive way.
 
 If point is a string or comment and
@@ -232,9 +232,9 @@ Otherwise if point is inside a bracketed list (e.g. a function
 call, an array declaration, etc.) then if the list is currently
 on a single line call `fill-function-arguments-to-multi-line',
 otherwise call `fill-function-arguments-to-single-line'."
-  (interactive)
+  (interactive "P")
   (if (fill-function-arguments--do-argument-fill-p)
-      (fill-paragraph)
+      (fill-paragraph arg t)
     (save-restriction
       (fill-function-arguments--narrow-to-brackets)
       (cond

--- a/fill-function-arguments.el
+++ b/fill-function-arguments.el
@@ -221,7 +221,7 @@ Borrowed from s.el to avoid a dependency"
             (indent-region (point-min) (point-max))))))))
 
 ;;;###autoload
-(defun fill-function-arguments-dwim (&optional arg)
+(defun fill-function-arguments-dwim ()
   "Fill the thing at point in a context-sensitive way.
 
 If point is a string or comment and
@@ -232,9 +232,9 @@ Otherwise if point is inside a bracketed list (e.g. a function
 call, an array declaration, etc.) then if the list is currently
 on a single line call `fill-function-arguments-to-multi-line',
 otherwise call `fill-function-arguments-to-single-line'."
-  (interactive "P")
+  (interactive)
   (if (fill-function-arguments--do-argument-fill-p)
-      (fill-paragraph arg t)
+      (call-interactively #'fill-paragraph)
     (save-restriction
       (fill-function-arguments--narrow-to-brackets)
       (cond


### PR DESCRIPTION
Today I learned that `fill-paragraph` supports prefix arg to justify the text. When checking out its docstring, I also found out that when called interactively, a second argument is set.

After testing in a comment, I found out this package doesn't pass the prefix when doing fallback.

In the commit history you will find a very "explicit" fix, and a more "correct" one, that happens to be smaller too. I am not super familiar with `call-interactively` but all seems to work as expected.